### PR TITLE
MEM-63-일기-작성-시-원하는-캐릭터-선택-하도록-API-수정

### DIFF
--- a/src/main/java/ac/mju/memoria/backend/domain/diary/dto/DiaryDto.java
+++ b/src/main/java/ac/mju/memoria/backend/domain/diary/dto/DiaryDto.java
@@ -5,6 +5,7 @@ import ac.mju.memoria.backend.domain.file.dto.FileDto;
 import ac.mju.memoria.backend.domain.user.dto.UserDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -31,6 +32,17 @@ public class DiaryDto {
 
         @Schema(description = "첨부 이미지 파일 목록")
         private List<MultipartFile> images;
+
+        @Schema(description = "답장을 바라는 AI 캐릭터 ID", example = "character_id_123")
+        private Long desiredCharacterId;
+
+        @Schema(description = "AI 답장 활성화 여부")
+        @NotNull
+        private boolean isAICommentEnabled;
+
+        @Schema(description = "AI 음악 생성 활성화 여부")
+        @NotNull
+        private boolean isAIMusicEnabled;
     }
 
     @Data

--- a/src/main/java/ac/mju/memoria/backend/domain/diary/event/AiCommentNeededEvent.java
+++ b/src/main/java/ac/mju/memoria/backend/domain/diary/event/AiCommentNeededEvent.java
@@ -1,17 +1,29 @@
 package ac.mju.memoria.backend.domain.diary.event;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.context.ApplicationEvent;
+
+import java.util.Optional;
 
 @Getter
 public class AiCommentNeededEvent extends ApplicationEvent {
     private final Long diaryId;
-    public AiCommentNeededEvent(Object source, Long diaryId) {
+    @Nullable
+    private final Long desiredCharacterId;
+
+    public AiCommentNeededEvent(Object source, Long diaryId, @Nullable Long desiredCharacterId) {
         super(source);
         this.diaryId = diaryId;
+        this.desiredCharacterId = desiredCharacterId;
     }
 
     public static AiCommentNeededEvent of(Object caller, Long diaryId) {
-        return new AiCommentNeededEvent(caller, diaryId);
+        return new AiCommentNeededEvent(caller, diaryId, null);
+    }
+
+    public static AiCommentNeededEvent of(Object caller, Long diaryId, Long desiredCharacterId) {
+        return new AiCommentNeededEvent(caller, diaryId, desiredCharacterId);
     }
 }

--- a/src/main/java/ac/mju/memoria/backend/domain/diary/service/DiaryService.java
+++ b/src/main/java/ac/mju/memoria/backend/domain/diary/service/DiaryService.java
@@ -67,9 +67,14 @@ public class DiaryService {
             savedImages.forEach(saved::addImage);
         }
 
-        musicCreateService.requestMusic(saved);
-        eventPublisher.publishEvent(AiCommentNeededEvent.of(this, saved.getId()));
-        eventPublisher.publishEvent(new NewDiaryEvent(saved.getId()));
+        if (requestDto.isAICommentEnabled()) {
+            eventPublisher.publishEvent(AiCommentNeededEvent.of(this, saved.getId(), requestDto.getDesiredCharacterId()));
+            eventPublisher.publishEvent(new NewDiaryEvent(saved.getId()));
+        }
+
+        if (requestDto.isAIMusicEnabled()) {
+            musicCreateService.requestMusic(saved);
+        }
 
         return DiaryDto.DiaryResponse.fromEntity(saved);
     }


### PR DESCRIPTION
- DiaryDto에 AI 캐릭터 ID 및 AI 댓글 활성화 여부 필드 추가
- AiCommentNeededEvent에 AI 캐릭터 ID 필드 추가 및 생성자 수정
- DiaryService에서 AI 댓글 및 음악 생성 요청 로직 개선